### PR TITLE
🔒 Security fix: Disable cleartext traffic and harden WebView

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Dashboard"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="false">
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/dashboard/android/WebAppFragment.kt
+++ b/app/src/main/java/com/dashboard/android/WebAppFragment.kt
@@ -89,7 +89,7 @@ class WebAppFragment : Fragment() {
             domStorageEnabled = true
             databaseEnabled = true
             mediaPlaybackRequiresUserGesture = false
-            mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+            mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
             cacheMode = WebSettings.LOAD_DEFAULT
             setSupportZoom(true)
             builtInZoomControls = true


### PR DESCRIPTION
The application was previously allowing cleartext network traffic via the `android:usesCleartextTraffic="true"` attribute in the manifest. This has been disabled to ensure all network communication is encrypted. Additionally, the WebView configuration was updated to prevent loading insecure HTTP resources within HTTPS pages (mixed content).

🎯 **What:** The vulnerability fixed is the allowance of unencrypted cleartext network traffic.
⚠️ **Risk:** Potential interception and modification of sensitive data by attackers via man-in-the-middle (MITM) attacks.
🛡️ **Solution:** Disabled cleartext traffic in the manifest and hardened WebView settings to disallow mixed content.

---
*PR created automatically by Jules for task [4673291396969322588](https://jules.google.com/task/4673291396969322588) started by @Awesomeguys9000*