### PR TITLE
Add music source to Now Playing display

### DIFF
--- a/app/src/main/java/com/dashboard/android/ClockFragment.kt
+++ b/app/src/main/java/com/dashboard/android/ClockFragment.kt
@@ -226,6 +226,18 @@ class ClockFragment : Fragment() {
                 binding.nowPlayingContainer.visibility = View.VISIBLE
                 binding.trackTitle.text = title.ifEmpty { getString(R.string.not_playing) }
                 binding.trackArtist.text = artist
+
+                // Update Media Source (App Name)
+                try {
+                    val packageName = controller.packageName
+                    val pm = requireContext().packageManager
+                    val appInfo = pm.getApplicationInfo(packageName, 0)
+                    val appName = pm.getApplicationLabel(appInfo).toString()
+                    binding.mediaSource.text = appName
+                    binding.mediaSource.visibility = View.VISIBLE
+                } catch (e: Exception) {
+                    binding.mediaSource.visibility = View.GONE
+                }
                 
                 val isPlaying = controller.playbackState?.state == PlaybackState.STATE_PLAYING
                 binding.btnPlayPause.setImageResource(

--- a/app/src/main/res/layout/fragment_clock.xml
+++ b/app/src/main/res/layout/fragment_clock.xml
@@ -62,6 +62,16 @@
             android:layout_marginEnd="16dp">
 
             <TextView
+                android:id="@+id/mediaSource"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="12sp"
+                android:textColor="@color/text_secondary"
+                android:maxLines="1"
+                android:ellipsize="end"
+                tools:text="Apple Music" />
+
+            <TextView
                 android:id="@+id/trackTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
Added the music source (application name) above the "Now Playing" track title in the clock fragment.
This allows users to see which app is currently playing media.
Implemented error handling to gracefully hide the view if the app name cannot be retrieved.

---
*PR created automatically by Jules for task [12806080143549966988](https://jules.google.com/task/12806080143549966988) started by @Awesomeguys9000*