### PR TITLE
Update Asana User-Agent for 2026

### DIFF
--- a/app/src/main/java/com/dashboard/android/AppConfig.kt
+++ b/app/src/main/java/com/dashboard/android/AppConfig.kt
@@ -63,7 +63,7 @@ data class AppConfig(
                 name = "Asana",
                 url = "https://app.asana.com",
                 iconResId = R.drawable.ic_asana,
-                customUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+                customUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
             ),
             AppConfig(
                 id = "youtube",


### PR DESCRIPTION
Updated the Asana web app configuration to use a newer User-Agent string (Chrome 146) appropriate for 2026, as requested. This prevents the "old browser" warning while maintaining the preferred desktop layout. Confirmed syntax correctness with `gradle compileDebugKotlin`.

---
*PR created automatically by Jules for task [8237626198078570006](https://jules.google.com/task/8237626198078570006) started by @Awesomeguys9000*