### PR TITLE
Add battery percentage indicator to ClockFragment

### DIFF
--- a/app/src/main/java/com/dashboard/android/ClockFragment.kt
+++ b/app/src/main/java/com/dashboard/android/ClockFragment.kt
@@ -14,6 +14,10 @@ import android.widget.ImageButton
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import com.dashboard.android.databinding.FragmentClockBinding
+import android.content.BroadcastReceiver
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -27,6 +31,66 @@ class ClockFragment : Fragment() {
     private var is24Hour = false
     private var showSeconds = true
     private var clockColor = 0xFFFFFFFF.toInt()
+
+    private val batteryReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            updateBatteryInfo(intent)
+        }
+    }
+
+    private var isFlashing = false
+
+    private val flashRunnable = object : Runnable {
+        override fun run() {
+            if (_binding != null) {
+                binding.batteryText.visibility = if (binding.batteryText.visibility == View.VISIBLE) View.INVISIBLE else View.VISIBLE
+                handler.postDelayed(this, 1000)
+            }
+        }
+    }
+
+    private fun updateBatteryInfo(intent: Intent) {
+        val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+        val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+        val plugged = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)
+
+        val percent = if (level != -1 && scale != -1) {
+            (level * 100) / scale
+        } else {
+            0
+        }
+
+        val isPlugged = plugged == BatteryManager.BATTERY_PLUGGED_AC ||
+                plugged == BatteryManager.BATTERY_PLUGGED_USB ||
+                plugged == BatteryManager.BATTERY_PLUGGED_WIRELESS
+
+        if (isPlugged) {
+            binding.batteryText.visibility = View.GONE
+            stopFlashing()
+        } else {
+            binding.batteryText.text = "$percent%"
+            if (percent <= 10) {
+                startFlashing()
+            } else {
+                stopFlashing()
+                binding.batteryText.visibility = View.VISIBLE
+            }
+        }
+    }
+
+    private fun startFlashing() {
+        if (!isFlashing) {
+            isFlashing = true
+            handler.post(flashRunnable)
+        }
+    }
+
+    private fun stopFlashing() {
+        if (isFlashing) {
+            isFlashing = false
+            handler.removeCallbacks(flashRunnable)
+        }
+    }
     
     private val clockRunnable = object : Runnable {
         override fun run() {
@@ -314,6 +378,7 @@ class ClockFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         handler.post(clockRunnable)
+        requireContext().registerReceiver(batteryReceiver, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
         
         // Setup media listeners
         val manager = requireContext().getSystemService(Context.MEDIA_SESSION_SERVICE) as android.media.session.MediaSessionManager
@@ -341,6 +406,8 @@ class ClockFragment : Fragment() {
     override fun onPause() {
         super.onPause()
         handler.removeCallbacks(clockRunnable)
+        requireContext().unregisterReceiver(batteryReceiver)
+        stopFlashing()
         
         // Cleanup media listeners
         val manager = requireContext().getSystemService(Context.MEDIA_SESSION_SERVICE) as android.media.session.MediaSessionManager

--- a/app/src/main/res/layout/fragment_clock.xml
+++ b/app/src/main/res/layout/fragment_clock.xml
@@ -11,6 +11,19 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <!-- Battery Percentage -->
+    <TextView
+        android:id="@+id/batteryText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|end"
+        android:layout_margin="24dp"
+        android:textSize="16sp"
+        android:textColor="@color/text_primary"
+        android:visibility="gone"
+        tools:text="85%"
+        tools:visibility="visible" />
+
     <!-- Clock Container -->
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Added a battery percentage indicator to the clock screen. It is visible only when the device is unplugged. If the battery level drops to 10% or below while unplugged, the indicator flashes at 0.5Hz. When plugged in, the indicator is hidden regardless of the battery level.

---
*PR created automatically by Jules for task [12350350618036697071](https://jules.google.com/task/12350350618036697071) started by @Awesomeguys9000*