### PR TITLE
Fix touch intercept bug in Notifications and OTP fragments

### DIFF
--- a/app/src/main/java/com/dashboard/android/NotificationsFragment.kt
+++ b/app/src/main/java/com/dashboard/android/NotificationsFragment.kt
@@ -40,6 +40,19 @@ class NotificationsFragment : Fragment(), NotificationService.NotificationUpdate
         binding.notificationsList.layoutManager = GridLayoutManager(context, 3)
         binding.notificationsList.adapter = adapter
         
+        // Prevent ViewPager2 from intercepting horizontal swipes
+        binding.notificationsList.addOnItemTouchListener(object : RecyclerView.OnItemTouchListener {
+            override fun onInterceptTouchEvent(rv: RecyclerView, e: android.view.MotionEvent): Boolean {
+                if (e.actionMasked == android.view.MotionEvent.ACTION_DOWN) {
+                    rv.parent?.requestDisallowInterceptTouchEvent(true)
+                }
+                return false
+            }
+
+            override fun onTouchEvent(rv: RecyclerView, e: android.view.MotionEvent) {}
+            override fun onRequestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {}
+        })
+
         // Swipe to dismiss
         val swipeHandler = object : ItemTouchHelper.SimpleCallback(
             0, ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT

--- a/app/src/main/java/com/dashboard/android/OtpFragment.kt
+++ b/app/src/main/java/com/dashboard/android/OtpFragment.kt
@@ -354,8 +354,9 @@ class OtpFragment : Fragment() {
                 true
             }
 
-            holder.binding.dragHandle.setOnTouchListener { _, event ->
+            holder.binding.dragHandle.setOnTouchListener { view, event ->
                 if (event.actionMasked == android.view.MotionEvent.ACTION_DOWN) {
+                    view.parent?.requestDisallowInterceptTouchEvent(true)
                     if (singleFingerScroll) {
                         onStartDrag(holder)
                     }


### PR DESCRIPTION
Fixes a bug where dragging 2FA codes or swiping notifications would lose pointer capture, resulting in janky interactions. The root cause was `ViewPager2` intercepting horizontal/vertical touches that were intended for the child `RecyclerView` items. By explicitly requesting parent to disallow intercepting touch events upon `ACTION_DOWN` during interactions, the interactions are smooth and no longer interrupted.

---
*PR created automatically by Jules for task [6506372350247941229](https://jules.google.com/task/6506372350247941229) started by @Awesomeguys9000*